### PR TITLE
feat: integrate oscd-shell npm module and partially style

### DIFF
--- a/index-web.js
+++ b/index-web.js
@@ -1,5 +1,5 @@
-// import '@webcomponents/scoped-custom-element-registry';
-// import '../dist/oscd-shell.js';
+import '@webcomponents/scoped-custom-element-registry';
+import '@omicronenergy/oscd-shell/oscd-shell.js';
 import OscdMenuOpen from '@omicronenergy/oscd-menu-open';
 import OscdMenuSave from '@omicronenergy/oscd-menu-save';
 import {

--- a/index.html
+++ b/index.html
@@ -8,19 +8,22 @@
     />
     <link
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;400;500;600&display=swap"
+    />
+    <link
+      rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Material+Symbols+Outlined&display=block"
     />
     <link rel="stylesheet" href="./colors.css" />
     <link rel="stylesheet" href="./theming.css" />
   </head>
   <body>
-    <oscd-shell locale="en"> </oscd-shell>
-    <script type="module">
-      // Known issue, scoped registry polyfill doesn't load as fast as oscd-shell, causing oscd-shell to fail.
-      // To safeguard, we await the polyfill first, then load the rest.
-      await import('@webcomponents/scoped-custom-element-registry');
-      await import('./dist/oscd-shell.js');
-      await import('./index-web.js');
-    </script>
+    <oscd-shell
+      locale="en"
+      appTitle="Sysconex"
+      landingPageHeading="Welcome to Sysconex"
+      landingPageSubHeading="A system configuration tool for digital substations"
+    ></oscd-shell>
+    <script type="module" src="index-web.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@omicronenergy/oscd-menu-commons": "^0.0.1",
         "@omicronenergy/oscd-menu-open": "^0.0.6",
         "@omicronenergy/oscd-menu-save": "^0.0.2",
+        "@omicronenergy/oscd-shell": "^0.0.13",
         "@omicronenergy/oscd-test-utils": "^0.0.8",
         "@omicronenergy/oscd-ui": "^0.0.9",
         "@open-wc/scoped-elements": "^3.0.6",
@@ -65,6 +66,76 @@
         "lint-staged": "^16.1.5",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.54.1",
+        "pngjs": "^7.0.0",
+        "prettier": "^3.6.2",
+        "rimraf": "^6.0.1",
+        "rollup": "^4.49.0",
+        "rollup-plugin-copy": "^3.5.0",
+        "sinon": "^21.0.0",
+        "tsdoc": "^0.0.4",
+        "typedoc": "^0.28.11",
+        "typescript": "^5.9.2"
+      }
+    },
+    "../../stee-re/oscd-shell": {
+      "name": "@omicronenergy/oscd-shell",
+      "version": "0.0.12",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lit/localize": "^0.12.2",
+        "@omicronenergy/oscd-background-editv1": "^0.0.6",
+        "@omicronenergy/oscd-editor": "^1.7.1",
+        "@omicronenergy/oscd-editor-source": "^0.0.1",
+        "@omicronenergy/oscd-menu-commons": "^0.0.1",
+        "@omicronenergy/oscd-menu-open": "^0.0.6",
+        "@omicronenergy/oscd-menu-save": "^0.0.2",
+        "@omicronenergy/oscd-test-utils": "^0.0.8",
+        "@omicronenergy/oscd-ui": "^0.0.9",
+        "@open-wc/scoped-elements": "^3.0.6",
+        "@openscd/oscd-api": "^0.1.6",
+        "@webcomponents/scoped-custom-element-registry": "^0.0.10",
+        "lit": "^3.3.1",
+        "tslib": "^2.8.1"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^19.8.1",
+        "@commitlint/config-conventional": "^19.8.1",
+        "@custom-elements-manifest/analyzer": "^0.10.5",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "^9.34.0",
+        "@lit/localize-tools": "^0.8.0",
+        "@open-wc/dev-server-hmr": "^0.2.0",
+        "@open-wc/eslint-config": "^13.0.0",
+        "@open-wc/testing": "^4.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.1",
+        "@rollup/plugin-typescript": "^12.1.4",
+        "@types/mocha": "^10.0.10",
+        "@typescript-eslint/eslint-plugin": "^8.41.0",
+        "@typescript-eslint/parser": "^8.41.0",
+        "@ungap/structured-clone": "^1.3.0",
+        "@web/dev-server": "^0.4.6",
+        "@web/dev-server-polyfill": "^1.0.6",
+        "@web/rollup-plugin-html": "^2.3.0",
+        "@web/rollup-plugin-import-meta-assets": "^2.3.0",
+        "@web/test-runner": "0.20.2",
+        "@web/test-runner-commands": "^0.9.0",
+        "@web/test-runner-playwright": "0.11.1",
+        "@web/test-runner-visual-regression": "0.9.0",
+        "concurrently": "^9.2.1",
+        "eslint": "^9.34.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-html": "^8.1.3",
+        "eslint-plugin-lit": "^2.1.1",
+        "eslint-plugin-lit-a11y": "^5.1.1",
+        "eslint-plugin-no-only-tests": "^3.3.0",
+        "eslint-plugin-prettier": "^5.5.4",
+        "eslint-plugin-tsdoc": "^0.4.0",
+        "eslint-plugin-wc": "^3.0.1",
+        "gh-pages": "^6.3.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.1.5",
+        "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
@@ -1834,6 +1905,48 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/@omicronenergy/oscd-background-editv1/node_modules/@omicronenergy/oscd-shell": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-shell/-/oscd-shell-0.0.7.tgz",
+      "integrity": "sha512-R+QuNLyxCMy+MeQ9Vecn/4Zlw9hwBpJLEDNGsGk2oODQOCJzfB9Dl93I8nr5VD4pEbP5pDKMO5kWOHN7A277GA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lit/localize": "^0.12.2",
+        "@omicronenergy/oscd-api": "^0.1.0",
+        "@omicronenergy/oscd-editor": "^1.5.0",
+        "@omicronenergy/oscd-test-utils": "^0.0.7",
+        "@omicronenergy/oscd-ui": "^0.0.4",
+        "@open-wc/scoped-elements": "^3.0.5",
+        "@webcomponents/scoped-custom-element-registry": "^0.0.10",
+        "lit": "^3.3.0",
+        "tslib": "^2.6.3"
+      }
+    },
+    "node_modules/@omicronenergy/oscd-background-editv1/node_modules/@omicronenergy/oscd-test-utils": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-test-utils/-/oscd-test-utils-0.0.7.tgz",
+      "integrity": "sha512-wK/t1+QBJVMT9JnOkgR6xbkB0w7Cnv7OhF0id8sS9Btv+5Bmf/5sRIi1yA9EIDEH3wtXb8vd3PiYd3LhvnawGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@omicronenergy/oscd-api": "^0.1.0",
+        "@open-wc/testing": "4.0.0",
+        "fast-check": "^3.22.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@omicronenergy/oscd-background-editv1/node_modules/@omicronenergy/oscd-ui": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-ui/-/oscd-ui-0.0.4.tgz",
+      "integrity": "sha512-qaMzMn1Pq0/fzQ0pGRRFBz0JnNa1pIeSDSLM/X+avW32arLBcU1QOUCGlVNohZr9P2YDmEwovgS1JXXmBvadZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/web": "2.3.0",
+        "@open-wc/scoped-elements": "^3.0.5",
+        "@webcomponents/scoped-custom-element-registry": "^0.0.10",
+        "lit": "^3.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@omicronenergy/oscd-editor": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-editor/-/oscd-editor-1.7.1.tgz",
@@ -2002,6 +2115,48 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/@omicronenergy/oscd-menu-open/node_modules/@omicronenergy/oscd-shell": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-shell/-/oscd-shell-0.0.7.tgz",
+      "integrity": "sha512-R+QuNLyxCMy+MeQ9Vecn/4Zlw9hwBpJLEDNGsGk2oODQOCJzfB9Dl93I8nr5VD4pEbP5pDKMO5kWOHN7A277GA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lit/localize": "^0.12.2",
+        "@omicronenergy/oscd-api": "^0.1.0",
+        "@omicronenergy/oscd-editor": "^1.5.0",
+        "@omicronenergy/oscd-test-utils": "^0.0.7",
+        "@omicronenergy/oscd-ui": "^0.0.4",
+        "@open-wc/scoped-elements": "^3.0.5",
+        "@webcomponents/scoped-custom-element-registry": "^0.0.10",
+        "lit": "^3.3.0",
+        "tslib": "^2.6.3"
+      }
+    },
+    "node_modules/@omicronenergy/oscd-menu-open/node_modules/@omicronenergy/oscd-test-utils": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-test-utils/-/oscd-test-utils-0.0.7.tgz",
+      "integrity": "sha512-wK/t1+QBJVMT9JnOkgR6xbkB0w7Cnv7OhF0id8sS9Btv+5Bmf/5sRIi1yA9EIDEH3wtXb8vd3PiYd3LhvnawGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@omicronenergy/oscd-api": "^0.1.0",
+        "@open-wc/testing": "4.0.0",
+        "fast-check": "^3.22.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@omicronenergy/oscd-menu-open/node_modules/@omicronenergy/oscd-ui": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-ui/-/oscd-ui-0.0.4.tgz",
+      "integrity": "sha512-qaMzMn1Pq0/fzQ0pGRRFBz0JnNa1pIeSDSLM/X+avW32arLBcU1QOUCGlVNohZr9P2YDmEwovgS1JXXmBvadZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/web": "2.3.0",
+        "@open-wc/scoped-elements": "^3.0.5",
+        "@webcomponents/scoped-custom-element-registry": "^0.0.10",
+        "lit": "^3.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@omicronenergy/oscd-menu-save": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-menu-save/-/oscd-menu-save-0.0.2.tgz",
@@ -2092,45 +2247,25 @@
       }
     },
     "node_modules/@omicronenergy/oscd-shell": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-shell/-/oscd-shell-0.0.7.tgz",
-      "integrity": "sha512-R+QuNLyxCMy+MeQ9Vecn/4Zlw9hwBpJLEDNGsGk2oODQOCJzfB9Dl93I8nr5VD4pEbP5pDKMO5kWOHN7A277GA==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-shell/-/oscd-shell-0.0.13.tgz",
+      "integrity": "sha512-bJuXdTIdEtqJ+uWk+K8MOMDViyYmCa6d1gIbVHhss+X4hUEod3u/4vSWbd2/55YHkwCMsgWrOkfH6G0UG/YOZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit/localize": "^0.12.2",
-        "@omicronenergy/oscd-api": "^0.1.0",
-        "@omicronenergy/oscd-editor": "^1.5.0",
-        "@omicronenergy/oscd-test-utils": "^0.0.7",
-        "@omicronenergy/oscd-ui": "^0.0.4",
-        "@open-wc/scoped-elements": "^3.0.5",
+        "@omicronenergy/oscd-background-editv1": "^0.0.6",
+        "@omicronenergy/oscd-editor": "^1.7.1",
+        "@omicronenergy/oscd-editor-source": "^0.0.1",
+        "@omicronenergy/oscd-menu-commons": "^0.0.1",
+        "@omicronenergy/oscd-menu-open": "^0.0.6",
+        "@omicronenergy/oscd-menu-save": "^0.0.2",
+        "@omicronenergy/oscd-test-utils": "^0.0.8",
+        "@omicronenergy/oscd-ui": "^0.0.9",
+        "@open-wc/scoped-elements": "^3.0.6",
+        "@openscd/oscd-api": "^0.1.6",
         "@webcomponents/scoped-custom-element-registry": "^0.0.10",
-        "lit": "^3.3.0",
-        "tslib": "^2.6.3"
-      }
-    },
-    "node_modules/@omicronenergy/oscd-shell/node_modules/@omicronenergy/oscd-test-utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-test-utils/-/oscd-test-utils-0.0.7.tgz",
-      "integrity": "sha512-wK/t1+QBJVMT9JnOkgR6xbkB0w7Cnv7OhF0id8sS9Btv+5Bmf/5sRIi1yA9EIDEH3wtXb8vd3PiYd3LhvnawGA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@omicronenergy/oscd-api": "^0.1.0",
-        "@open-wc/testing": "4.0.0",
-        "fast-check": "^3.22.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@omicronenergy/oscd-shell/node_modules/@omicronenergy/oscd-ui": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@omicronenergy/oscd-ui/-/oscd-ui-0.0.4.tgz",
-      "integrity": "sha512-qaMzMn1Pq0/fzQ0pGRRFBz0JnNa1pIeSDSLM/X+avW32arLBcU1QOUCGlVNohZr9P2YDmEwovgS1JXXmBvadZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@material/web": "2.3.0",
-        "@open-wc/scoped-elements": "^3.0.5",
-        "@webcomponents/scoped-custom-element-registry": "^0.0.10",
-        "lit": "^3.0.0",
-        "tslib": "^2.4.0"
+        "lit": "^3.3.1",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@omicronenergy/oscd-test-utils": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@omicronenergy/oscd-menu-commons": "^0.0.1",
     "@omicronenergy/oscd-menu-open": "^0.0.6",
     "@omicronenergy/oscd-menu-save": "^0.0.2",
+    "@omicronenergy/oscd-shell": "^0.0.13",
     "@omicronenergy/oscd-test-utils": "^0.0.8",
     "@omicronenergy/oscd-ui": "^0.0.9",
     "@open-wc/scoped-elements": "^3.0.6",

--- a/theming.css
+++ b/theming.css
@@ -12,7 +12,7 @@
   /* optional emphasized content */
   --oscd-theme-base01: var(--ops-bg-lt-700);
   /* body text / primary content */
-  --oscd-theme-base00: var(--ops-bg-lt-600); 
+  --oscd-theme-base00: var(--ops-bg-lt-600);
 
   --oscd-theme-base0: var(--ops-bg-lt-300);
   /* comments/secondary content */
@@ -22,9 +22,9 @@
   /* background */
   --oscd-theme-base3: var(--ops-bg-lt-50);
 
-  --oscd-theme-text-font: "Fira Sans";
-  --oscd-theme-icon-font: "Material Symbols Outlined";
-  --oscd-theme-text-font-mono: "Roboto Mono";
+  --oscd-theme-text-font: 'Fira Sans';
+  --oscd-theme-icon-font: 'Material Symbols Outlined';
+  --oscd-theme-text-font-mono: 'Roboto Mono';
 
   --primary: var(--oscd-theme-primary);
   --secondary: var(--oscd-theme-secondary);
@@ -36,28 +36,48 @@
 
 @media (prefers-color-scheme: dark) {
   * {
-  --oscd-theme-heading: var(--ops-landing-dark);
+    --oscd-theme-heading: var(--ops-landing-dark);
 
-  --oscd-theme-primary: var(--ops-primary-dark);
-  --oscd-theme-secondary: var(--ops-secondary-dark);
-  --oscd-theme-error: var(--ops-error-red);
+    --oscd-theme-primary: var(--ops-primary-dark);
+    --oscd-theme-secondary: var(--ops-secondary-dark);
+    --oscd-theme-error: var(--ops-error-red);
 
-  --oscd-theme-base03: var(--ops-bg-dk-900);
-  --oscd-theme-base02: var(--ops-bg-dk-800);
-  /* optional emphasized content */
-  --oscd-theme-base01: var(--ops-bg-dk-400);
-  /* body text / primary content */
-  --oscd-theme-base00: var(--ops-bg-dk-200); 
+    --oscd-theme-base03: var(--ops-bg-dk-900);
+    --oscd-theme-base02: var(--ops-bg-dk-800);
+    /* optional emphasized content */
+    --oscd-theme-base01: var(--ops-bg-dk-400);
+    /* body text / primary content */
+    --oscd-theme-base00: var(--ops-bg-dk-200);
 
-  --oscd-theme-base0: var(--ops-bg-dk-500);
-  /* comments/secondary content */
-  --oscd-theme-base1: var(--ops-bg-dk-600);
-  /* background highlights */
-  --oscd-theme-base2: var(--ops-bg-dk-700);
-  /* background */
-  --oscd-theme-base3: var(--ops-bg-dk-900);
-  
-  --mdc-theme-text-disabled-on-light: rgba(255, 255, 255, 0.38);
+    --oscd-theme-base0: var(--ops-bg-dk-500);
+    /* comments/secondary content */
+    --oscd-theme-base1: var(--ops-bg-dk-600);
+    /* background highlights */
+    --oscd-theme-base2: var(--ops-bg-dk-700);
+    /* background */
+    --oscd-theme-base3: var(--ops-bg-dk-900);
+
+    --mdc-theme-text-disabled-on-light: rgba(255, 255, 255, 0.38);
+
+    /* Shell Customizations */
+
+    /* Landing page */
+    --oscd-shell-landing-heading-color: var(--oscd-theme-primary);
+    --oscd-shell-landing-subheading-color: var(--oscd-theme-primary);
+    --oscd-shell-landing-heading-size: 24px;
+
+    --oscd-shell-landing-card-background: var(--oscd-theme-base01);
+
+    /* App Bar */
+    --oscd-shell-app-bar-title-color: var(--oscd-theme-base00);
+
+    /* Plugins Menu */
+    --oscd-shell-plugins-menu-button-color: var(--oscd-theme-base00);
+    --oscd-shell-editor-plugins-panel-item-text-color: var(--oscd-theme-base0);
+    --oscd-shell-editor-plugins-panel-item-icon-color: var(--oscd-theme-base0);
+
+    --oscd-shell-file-menu-text-color: var(--oscd-theme-base00);
+    --oscd-shell-app-bar-action-icon-color: var(--oscd-theme-base00);
   }
 }
 


### PR DESCRIPTION
As promised, I switch over to using the npm version of the oscd-shell and also extended the oscd-shell to support (hopfully all) the css variables you need.

If you discover some variables are missing, You could really help me by pointing out the variables which are missing and I'll integrate them with priority.

If missing css variables are hurting your eyes, to quickly regain the freedom to tweak the shell, I suggest cloning the oscd-shell locally somewhere, then after the `npm install`, do an `sudo npm link` at the root of the project. This will make the node module linkable.
Then in your distro, do a `sudo npm link @omicronenergy/oscd-shell` to link to the shell.
To undo, use `npm unlink @omicronenergy/oscd-shell`

Curious as to what variables exist in the shell? checkout  [THEMING.md](https://github.com/stee-re/oscd-shell/blob/main/THEMING.md)